### PR TITLE
add watch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,5 @@ preBuild/*/*.js
 plugins/*/*.js
 plugins/*.js
 docs/*.md
+_docs
 static/entitiesMap.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@docusaurus/module-type-aliases": "^2.4.0",
         "@tsconfig/docusaurus": "^1.0.7",
+        "nodemon": "^3.0.1",
         "typescript": "^4.9.5"
       },
       "engines": {
@@ -4335,6 +4336,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
       "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA=="
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -8644,6 +8651,12 @@
         "node": ">= 4"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
     "node_modules/image-size": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.2.tgz",
@@ -9879,10 +9892,83 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
+    "node_modules/nodemon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
+      "integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^3.2.7",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/non-layered-tidy-tree-layout": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
       "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="
+    },
+    "node_modules/nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -11091,6 +11177,12 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "1.4.1",
@@ -12966,6 +13058,18 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sirv": {
       "version": "1.0.19",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-1.0.19.tgz",
@@ -13610,6 +13714,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
+      "dev": true,
+      "dependencies": {
+        "nopt": "~1.0.10"
+      },
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -13761,6 +13877,12 @@
       "peerDependencies": {
         "react": ">=15.0.0"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "node_modules/unherit": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
+    "watch": "./scripts/tsc.sh; npm run start & nodemon -w ../docs -e md --exec \"./scripts/copy_src.sh; npm run preBuild\"",
     "build": "./scripts/copy_src.sh; ./scripts/tsc.sh; npm run preBuild; docusaurus build",
     "preBuild": "npm run numerationSystem; npm run addBibliographyTitle; npm run checkBrokenExternalLinks",
     "build_with_kaitai": "./scripts/kaitai_render.sh; ./scripts/copy_src.sh; ./scripts/tsc.sh; npm run preBuild_with_kaitai; docusaurus build",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^2.4.0",
     "@tsconfig/docusaurus": "^1.0.7",
+    "nodemon": "^3.0.1",
     "typescript": "^4.9.5"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "watch": "./scripts/tsc.sh; npm run start & nodemon -w ../docs -e md --exec \"./scripts/copy_src.sh; npm run preBuild\"",
+    "_watchBuild": "./scripts/copy_src.sh; WATCH_MODE=1 npm run numerationSystem; WATCH_MODE=1 npm run addBibliographyTitle; node ./preBuild/moveToDocusaurus/index.js",
+    "watch": "./scripts/tsc.sh; npm run start & nodemon -w ../docs -e md --exec \"npm run _watchBuild\"",
     "build": "./scripts/copy_src.sh; ./scripts/tsc.sh; npm run preBuild; docusaurus build",
     "preBuild": "npm run numerationSystem; npm run addBibliographyTitle; npm run checkBrokenExternalLinks",
     "build_with_kaitai": "./scripts/kaitai_render.sh; ./scripts/copy_src.sh; ./scripts/tsc.sh; npm run preBuild_with_kaitai; docusaurus build",

--- a/preBuild/addBibliographyTitle/index.ts
+++ b/preBuild/addBibliographyTitle/index.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-const mdPath = "docs";
+const mdPath = process.env.WATCH_MODE ? '_docs' : 'docs';
 
 const addBibliographyTitle = () => {
     const mdFileNames = fs.readdirSync(mdPath).filter((fileName) => {

--- a/preBuild/moveToDocusaurus/index.ts
+++ b/preBuild/moveToDocusaurus/index.ts
@@ -1,0 +1,17 @@
+import * as fs from 'fs';
+const sidebarRoutes = require('../sidebarRoutes');
+const fromDir = "_docs"
+const toDir = "docs"
+
+for (const { id: routeId } of sidebarRoutes) {
+  const from = `${fromDir}/${routeId}.md`;
+  const to = `${toDir}/${routeId}.md`;
+  if (!fs.existsSync(from)) continue;
+  const content = fs.readFileSync(from, "utf8");
+  try {
+    const oldContent = fs.readFileSync(to, "utf8");
+    // skip writing if unchanged
+    if(content === oldContent) continue;
+  } catch {} // dismiss error when `to` does not exist
+  fs.writeFileSync(to, content);
+}

--- a/preBuild/numerationSystem/index.ts
+++ b/preBuild/numerationSystem/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 const sidebarRoutes = require('../sidebarRoutes');
 const filePathIn = 'src/docs'
-const filePathOut = 'docs'
+const filePathOut = process.env.WATCH_MODE ? '_docs' : 'docs'
 const entitiesMapPathOut = 'static'
 
 export interface MdFile {


### PR DESCRIPTION
This PR adds a `watch` script which automatically rebuilds the website when the source `../docs` is changed. (I initially hacked something together for my own use, but I figured if I cleaned it up, it could be useful to others as well.)

The first commit adds a simple watch script using `nodemon`. However, this is quite slow, as every change writes to every file in `docs/`, forcing docusaurus to rebuild the whole website.

The second commit tweaks the build script a little bit to, when in watch mode, write to an intermediate `_docs` directory, instead of writing to `docs` directly. A small script `moveToDocusaurus` then copies over only the changed files.

Not writing unchanged files could be accomplished more cleanly, but I did not want to change the existing build script very much.