### PR TITLE
Update index.tsx

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -15,7 +15,7 @@ const FeatureList: FeatureItem[] = [
     Svg: require('@site/static/img/rust-svgrepo-com.svg').default,
     description: (
       <>
-        See <code><a href="https://github.com/paritytech/polkadot">Node Implementation by Parity</a></code>
+        See <code><a href="https://github.com/paritytech/polkadot-sdk/tree/master/polkadot">Node Implementation by Parity</a></code>
         &nbsp;and&nbsp;
         <code><a href="https://github.com/smol-dot/smoldot">smoldot</a></code>
       </>


### PR DESCRIPTION
The current link leads to the former Polkadot repo before the formation of the Polkadot SDK.

Hence, this PR updates the hyperlink to the current Polkadot SDK.