### PR TITLE
Polkadot to Polkadot SDK GH Repo Fix

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -15,7 +15,7 @@ const FeatureList: FeatureItem[] = [
     Svg: require('@site/static/img/rust-svgrepo-com.svg').default,
     description: (
       <>
-        See <code><a href="https://github.com/paritytech/polkadot">Node Implementation by Parity</a></code>
+        See <code><a href="https://github.com/paritytech/polkadot-sdk">Node Implementation by Parity</a></code>
         &nbsp;and&nbsp;
         <code><a href="https://github.com/smol-dot/smoldot">smoldot</a></code>
       </>


### PR DESCRIPTION
Currently, the website is pointing towards the archived repo https://github.com/paritytech/polkadot
However, it should point towards https://github.com/paritytech/polkadot-sdk